### PR TITLE
[159236641] Export Library Files

### DIFF
--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/configuration/ExporterGeneralProperties.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/configuration/ExporterGeneralProperties.java
@@ -1,0 +1,13 @@
+package uk.ac.ebi.biostd.exporter.configuration;
+
+import java.util.List;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "jobs")
+public class ExporterGeneralProperties {
+    private List<String> libFileProjects;
+}

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/configuration/GeneralConfiguration.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/configuration/GeneralConfiguration.java
@@ -3,7 +3,6 @@ package uk.ac.ebi.biostd.exporter.configuration;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -16,12 +15,9 @@ import uk.ac.ebi.biostd.remote.service.RemoteService;
 /**
  * Contains Beans declarations required as dependencies al around the project.
  */
-@Configuration
 @Slf4j
+@Configuration
 public class GeneralConfiguration {
-    @Value("{jobs.libFileProjects}")
-    private List<String> libFileProjects;
-
     @Bean
     public ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
@@ -45,10 +41,5 @@ public class GeneralConfiguration {
     @Bean
     public MagicFolderUtil magicFolderUtil(UsersFoldersProperties properties) {
         return new MagicFolderUtil(properties.getBaseDropboxPath(), properties.getSymLinksPath());
-    }
-
-    @Bean
-    public List<String> libFileProjects() {
-        return libFileProjects;
     }
 }

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/configuration/GeneralConfiguration.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/configuration/GeneralConfiguration.java
@@ -3,6 +3,7 @@ package uk.ac.ebi.biostd.exporter.configuration;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -18,6 +19,8 @@ import uk.ac.ebi.biostd.remote.service.RemoteService;
 @Configuration
 @Slf4j
 public class GeneralConfiguration {
+    @Value("{jobs.libFileProjects}")
+    private List<String> libFileProjects;
 
     @Bean
     public ObjectMapper objectMapper() {
@@ -42,5 +45,10 @@ public class GeneralConfiguration {
     @Bean
     public MagicFolderUtil magicFolderUtil(UsersFoldersProperties properties) {
         return new MagicFolderUtil(properties.getBaseDropboxPath(), properties.getSymLinksPath());
+    }
+
+    @Bean
+    public List<String> libFileProjects() {
+        return libFileProjects;
     }
 }

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/jobs/full/FullJobJobsFactory.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/jobs/full/FullJobJobsFactory.java
@@ -33,7 +33,7 @@ public class FullJobJobsFactory extends BaseJobsFactory implements JobsFactory {
         return newForkJob(
                 FORK_BATCH_SIZE,
                 FORK_JOB,
-                new DbRecordReader<>(submissionDao::getSubmissions, dataSource),
+                new DbRecordReader<>(submissionDao::getLibFileSubmissions, dataSource),
                 workQueues);
     }
 

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/jobs/full/FullJobJobsFactory.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/jobs/full/FullJobJobsFactory.java
@@ -33,7 +33,7 @@ public class FullJobJobsFactory extends BaseJobsFactory implements JobsFactory {
         return newForkJob(
                 FORK_BATCH_SIZE,
                 FORK_JOB,
-                new DbRecordReader<>(submissionDao::getLibFileSubmissions, dataSource),
+                new DbRecordReader<>(submissionDao::getSubmissions, dataSource),
                 workQueues);
     }
 

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/model/Section.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/model/Section.java
@@ -48,6 +48,11 @@ public class Section {
     @XmlElement(name = "file")
     private List<File> files;
 
+    @JsonProperty("libraryFile")
+    @JsonInclude(Include.NON_NULL)
+    @XmlAttribute(name = "libraryFile")
+    private String libraryFile;
+
     @JsonProperty("links")
     @JsonInclude(Include.NON_EMPTY)
     private List<Link> links;

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/model/Submission.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/model/Submission.java
@@ -83,4 +83,7 @@ public class Submission {
 
     @JsonIgnore
     private boolean released;
+
+    @JsonIgnore
+    private boolean libFileSubmission;
 }

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/Queries.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/Queries.java
@@ -19,6 +19,7 @@ public class Queries {
     private String linksBySectionQuery;
     private String sectionAttributesQuery;
     private String sectionFilesQuery;
+    private String sectionFilesCountQuery;
     private String sectionSectionsQuery;
     private String sectionByIdQuery;
     private String submissionAccessTagQuery;

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/Queries.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/Queries.java
@@ -13,8 +13,6 @@ import org.springframework.stereotype.Component;
 public class Queries {
 
     private String submissionsQuery;
-    private String regularSubmissionsQuery;
-    private String libFileSubmissionsQuery;
     private String submissionsPmcQuery;
     private String fileAttributesQuery;
     private String linkAttributesQuery;

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/Queries.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/Queries.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Component;
 public class Queries {
 
     private String submissionsQuery;
+    private String regularSubmissionsQuery;
+    private String libFileSubmissionsQuery;
     private String submissionsPmcQuery;
     private String fileAttributesQuery;
     private String linkAttributesQuery;

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/dao/SectionDao.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/dao/SectionDao.java
@@ -33,6 +33,11 @@ public class SectionDao {
         return template.query(queries.getSectionFilesQuery(), singletonMap("section_id", sectionId), fileMapper);
     }
 
+    public Long getSectionFilesCount(long sectionId) {
+        return template.queryForObject(
+                queries.getSectionFilesCountQuery(), singletonMap("section_id", sectionId), Long.class);
+    }
+
     public Section getSection(long sectionId) {
         return template.queryForObject(
                 queries.getSectionByIdQuery(), singletonMap("section_id", sectionId), sectionMapper);

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/dao/SubmissionDao.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/dao/SubmissionDao.java
@@ -5,9 +5,6 @@ import static java.util.Collections.singletonMap;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
@@ -28,11 +25,11 @@ import uk.ac.ebi.biostd.exporter.persistence.model.SubAndUserInfo;
 public class SubmissionDao {
 
     private final Queries queries;
-    private final NamedParameterJdbcTemplate template;
     private final AttributeMapper attributeMapper;
     private final SubmissionMapper submissionMapper;
-    private final LibFileSubmissionMapper libFileSubmissionMapper;
+    private final NamedParameterJdbcTemplate template;
     private final ExporterGeneralProperties properties;
+    private final LibFileSubmissionMapper libFileSubmissionMapper;
 
     public void releaseSubmission(long submissionId) {
         template.update(queries.getReleaseSubmission(), ImmutableMap.of("subId", submissionId));
@@ -82,19 +79,10 @@ public class SubmissionDao {
     }
 
     public List<Submission> getSubmissions() {
-        return template.query(queries.getSubmissionsQuery(), emptyMap(), submissionMapper);
-    }
-
-    public List<Submission> getLibFileSubmissions() {
-        Map<String, List<String>> projects = singletonMap("projects", properties.getLibFileProjects());
-
-        List<Submission> regularSubmissions =
-                template.query(queries.getRegularSubmissionsQuery(), projects, submissionMapper);
-
-        List<Submission> libFileSubmissions =
-                template.query(queries.getLibFileSubmissionsQuery(), projects, libFileSubmissionMapper);
-
-        return Stream.concat(libFileSubmissions.stream(), regularSubmissions.stream()).collect(Collectors.toList());
+        return template.query(
+                queries.getSubmissionsQuery(),
+                singletonMap("libFileProjects", properties.getLibFileProjects()),
+                libFileSubmissionMapper);
     }
 
     public List<Submission> getPmcSubmissions() {

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/dao/SubmissionDao.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/dao/SubmissionDao.java
@@ -5,28 +5,34 @@ import static java.util.Collections.singletonMap;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
+import uk.ac.ebi.biostd.exporter.configuration.ExporterGeneralProperties;
 import uk.ac.ebi.biostd.exporter.model.Attribute;
 import uk.ac.ebi.biostd.exporter.model.Submission;
 import uk.ac.ebi.biostd.exporter.persistence.Queries;
-import uk.ac.ebi.biostd.exporter.persistence.common.PaginatedResult;
 import uk.ac.ebi.biostd.exporter.persistence.mappers.AttributeMapper;
+import uk.ac.ebi.biostd.exporter.persistence.mappers.LibFileSubmissionMapper;
 import uk.ac.ebi.biostd.exporter.persistence.mappers.SubmissionMapper;
 import uk.ac.ebi.biostd.exporter.persistence.model.SubAndUserInfo;
 
+@Slf4j
 @Component
 @AllArgsConstructor
-@Slf4j
 public class SubmissionDao {
 
     private final Queries queries;
     private final NamedParameterJdbcTemplate template;
     private final AttributeMapper attributeMapper;
     private final SubmissionMapper submissionMapper;
+    private final LibFileSubmissionMapper libFileSubmissionMapper;
+    private final ExporterGeneralProperties properties;
 
     public void releaseSubmission(long submissionId) {
         template.update(queries.getReleaseSubmission(), ImmutableMap.of("subId", submissionId));
@@ -77,6 +83,18 @@ public class SubmissionDao {
 
     public List<Submission> getSubmissions() {
         return template.query(queries.getSubmissionsQuery(), emptyMap(), submissionMapper);
+    }
+
+    public List<Submission> getLibFileSubmissions() {
+        Map<String, List<String>> projects = singletonMap("projects", properties.getLibFileProjects());
+
+        List<Submission> regularSubmissions =
+                template.query(queries.getRegularSubmissionsQuery(), projects, submissionMapper);
+
+        List<Submission> libFileSubmissions =
+                template.query(queries.getLibFileSubmissionsQuery(), projects, libFileSubmissionMapper);
+
+        return Stream.concat(libFileSubmissions.stream(), regularSubmissions.stream()).collect(Collectors.toList());
     }
 
     public List<Submission> getPmcSubmissions() {

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/mappers/LibFileSubmissionMapper.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/mappers/LibFileSubmissionMapper.java
@@ -1,0 +1,17 @@
+package uk.ac.ebi.biostd.exporter.persistence.mappers;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.biostd.exporter.model.Submission;
+
+@Component
+public class LibFileSubmissionMapper extends SubmissionMapper {
+    @Override
+    public Submission mapRow(ResultSet resultSet, int rowNum) throws SQLException {
+        Submission submission = super.mapRow(resultSet, rowNum);
+        submission.setLibFileSubmission(true);
+
+        return submission;
+    }
+}

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/mappers/LibFileSubmissionMapper.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/persistence/mappers/LibFileSubmissionMapper.java
@@ -10,7 +10,7 @@ public class LibFileSubmissionMapper extends SubmissionMapper {
     @Override
     public Submission mapRow(ResultSet resultSet, int rowNum) throws SQLException {
         Submission submission = super.mapRow(resultSet, rowNum);
-        submission.setLibFileSubmission(true);
+        submission.setLibFileSubmission(resultSet.getBoolean("isLibFile"));
 
         return submission;
     }

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/service/SubmissionService.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/service/SubmissionService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import uk.ac.ebi.biostd.exporter.configuration.GeneralConfiguration;
 import uk.ac.ebi.biostd.exporter.model.Attribute;
 import uk.ac.ebi.biostd.exporter.model.File;
 import uk.ac.ebi.biostd.exporter.model.Link;
@@ -21,11 +22,14 @@ import uk.ac.ebi.biostd.exporter.utils.DateUtils;
 @Service
 @AllArgsConstructor
 public class SubmissionService {
+    private static final String SEPARATOR = ".";
+    private static final String LIB_FILE_SUFFIX = ".files.json";
 
     private final SubmissionDao submissionDao;
     private final SectionDao sectionDao;
     private final FilesDao filesDao;
     private final LinksDao linksDao;
+    private final GeneralConfiguration config;
 
     public List<Submission> getUpdatedSubmissions(long syncTime) {
         List<Submission> submissions = submissionDao.getUpdatedSubmissions(syncTime);
@@ -39,10 +43,13 @@ public class SubmissionService {
 
     public Submission processSubmission(Submission submission) {
         log.debug("processing submissions with accno: '{}' and id '{}'", submission.getAccno(), submission.getId());
+        List<Attribute> attributes = getAttributes(submission);
+
         submission.setAccessTags(getAccessTags(submission));
-        submission.setAttributes(getAttributes(submission));
+        submission.setAttributes(attributes);
+
         if (submission.getRootSection_id() != 0) {
-            submission.setSection(processSection(sectionDao.getSection(submission.getRootSection_id())));
+            submission.setSection(processSection(sectionDao.getSection(submission.getRootSection_id()), submission));
         }
 
         return submission;
@@ -66,27 +73,49 @@ public class SubmissionService {
         return subAttributes;
     }
 
-    private Section processSection(Section section) {
+    private Section processSection(Section section, Submission parentSubmission) {
         section.setAttributes(sectionDao.getSectionAttributes(section.getId()));
 
-        List<File> files = sectionDao.getSectionFiles(section.getId());
-        files.forEach(file -> file.setAttributes(filesDao.getFilesAttributes(file.getId())));
-        section.setFiles(files);
+        if (isLibFileSubmission(parentSubmission.getAttributes(), config.libFileProjects()) &&
+            sectionDao.getSectionFilesCount(section.getId()) > 0) {
+            section.setLibraryFile(getLibFileName(parentSubmission, section));
+        } else {
+            List<File> files = sectionDao.getSectionFiles(section.getId());
+            files.forEach(file -> file.setAttributes(filesDao.getFilesAttributes(file.getId())));
+            section.setFiles(files);
+        }
 
         List<Link> links = linksDao.getLinks(section.getId());
         links.forEach(link -> link.setAttributes(linksDao.getLinkAttributes(link.getId())));
         section.setLinks(links);
 
         List<Section> subSections = sectionDao.getSectionSections(section.getId());
-        subSections.forEach(this::processSection);
+        subSections.forEach(subSection -> processSection(subSection, parentSubmission));
         section.setSubsections(subSections);
 
         return section;
+    }
+
+    private String getLibFileName(Submission parentSubmission, Section section) {
+        StringBuilder libFile = new StringBuilder();
+        libFile.append(parentSubmission.getAccno())
+                .append(SEPARATOR)
+                .append(section.getId())
+                .append(LIB_FILE_SUFFIX);
+
+        return libFile.toString();
     }
 
     public Submission getSubmission(String accNo) {
         Submission submission = submissionDao.getSubmissionByAccNo(accNo);
         processSubmission(submission);
         return submission;
+    }
+
+    private boolean isLibFileSubmission(List<Attribute> attributes, List<String> libFileProjects) {
+        return attributes.stream()
+                .filter(attr -> attr.getName().equals("AttachTo"))
+                .filter(attr -> !libFileProjects.contains(attr.getValue()))
+                .count() > 0;
     }
 }

--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/service/SubmissionService.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/service/SubmissionService.java
@@ -5,7 +5,6 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import uk.ac.ebi.biostd.exporter.configuration.GeneralConfiguration;
 import uk.ac.ebi.biostd.exporter.model.Attribute;
 import uk.ac.ebi.biostd.exporter.model.File;
 import uk.ac.ebi.biostd.exporter.model.Link;
@@ -29,7 +28,6 @@ public class SubmissionService {
     private final SectionDao sectionDao;
     private final FilesDao filesDao;
     private final LinksDao linksDao;
-    private final GeneralConfiguration config;
 
     public List<Submission> getUpdatedSubmissions(long syncTime) {
         List<Submission> submissions = submissionDao.getUpdatedSubmissions(syncTime);
@@ -76,8 +74,7 @@ public class SubmissionService {
     private Section processSection(Section section, Submission parentSubmission) {
         section.setAttributes(sectionDao.getSectionAttributes(section.getId()));
 
-        if (isLibFileSubmission(parentSubmission.getAttributes(), config.libFileProjects()) &&
-            sectionDao.getSectionFilesCount(section.getId()) > 0) {
+        if (parentSubmission.isLibFileSubmission() && sectionDao.getSectionFilesCount(section.getId()) > 0) {
             section.setLibraryFile(getLibFileName(parentSubmission, section));
         } else {
             List<File> files = sectionDao.getSectionFiles(section.getId());
@@ -110,12 +107,5 @@ public class SubmissionService {
         Submission submission = submissionDao.getSubmissionByAccNo(accNo);
         processSubmission(submission);
         return submission;
-    }
-
-    private boolean isLibFileSubmission(List<Attribute> attributes, List<String> libFileProjects) {
-        return attributes.stream()
-                .filter(attr -> attr.getName().equals("AttachTo"))
-                .filter(attr -> !libFileProjects.contains(attr.getValue()))
-                .count() > 0;
     }
 }

--- a/Exporter/src/main/resources/application.yml
+++ b/Exporter/src/main/resources/application.yml
@@ -36,6 +36,8 @@ spring:
 
 jobs:
   backend-url: http://localhost:8586/biostd
+  libFileProjects:
+  - BioImages
   stats:
     enabled: false
     basePath: # ${SUBMISSIONS_PATH}/submission
@@ -84,6 +86,8 @@ spring:
   profiles: dev
 jobs:
   backend-url: http://biostudy-bia.ebi.ac.uk:8586/biostd
+  libFileProjects:
+  - BioImages
   dummy:
     enabled: false
     cron: 0/10 * * * * ? # each 10 seconds
@@ -126,6 +130,8 @@ spring:
   profiles: beta
 jobs:
   backend-url: http://biostudy-dev.ebi.ac.uk:10180/biostd-beta
+  libFileProjects:
+  - BioImages
   dummy:
     enabled: false
     cron: 0/10 * * * * ? # each 10 seconds
@@ -167,6 +173,8 @@ spring:
   profiles: prod
 jobs:
   backend-url: http://biostudy-prod.ebi.ac.uk:10080/biostd-prod
+  libFileProjects:
+  - BioImages
   dummy:
     enabled: false
     cron: 0/10 * * * * ? # each 10 seconds

--- a/Exporter/src/main/resources/queries.xml
+++ b/Exporter/src/main/resources/queries.xml
@@ -101,6 +101,10 @@
     select id, name, size, path from FileRef where sectionId = :section_id
   </entry>
 
+  <entry key="sectionFilesCountQuery">
+    select count(id) from FileRef where sectionId = :section_id
+  </entry>
+
   <entry key="sectionSectionsQuery">
     select id, accno, type from Section where parent_id = :section_id
   </entry>

--- a/Exporter/src/main/resources/queries.xml
+++ b/Exporter/src/main/resources/queries.xml
@@ -71,6 +71,26 @@
     WHERE version > 0
   </entry>
 
+  <entry key="regularSubmissionsQuery">
+    SELECT id, accno, title, secretKey, released, relPath, rTime, cTime, mTime, rootSection_id, owner_id from Submission
+    WHERE version > 0 AND
+      id NOT IN (SELECT su.id
+                  FROM Submission su, SubmissionAttribute sua
+                  WHERE su.id = sua.submission_id AND
+                  sua.name = 'AttachTo' AND
+                  sua.value IN (:projects) AND
+                  su.version > 0)
+  </entry>
+
+  <entry key="libFileSubmissionsQuery">
+    SELECT su.id, accno, title, secretKey, released, relPath, rTime, cTime, mTime, rootSection_id, owner_id
+    FROM Submission su, SubmissionAttribute sua
+    WHERE su.id = sua.submission_id AND
+      sua.name = 'AttachTo' AND
+      sua.value IN (:projects) AND
+      su.version > 0
+  </entry>
+
   <entry key="submissionsPmcQuery">
     SELECT id, accno, released, title, secretKey, relPath, rTime, cTime, mTime, rootSection_id, owner_id from Submission
     WHERE version > 0 AND accNo LIKE 'S-EPMC%'

--- a/Exporter/src/main/resources/queries.xml
+++ b/Exporter/src/main/resources/queries.xml
@@ -67,28 +67,14 @@
   </entry>
 
   <entry key="submissionsQuery">
-    SELECT id, accno, title, secretKey, released, relPath, rTime, cTime, mTime, rootSection_id, owner_id from Submission
-    WHERE version > 0
-  </entry>
-
-  <entry key="regularSubmissionsQuery">
-    SELECT id, accno, title, secretKey, released, relPath, rTime, cTime, mTime, rootSection_id, owner_id from Submission
-    WHERE version > 0 AND
-      id NOT IN (SELECT su.id
-                  FROM Submission su, SubmissionAttribute sua
-                  WHERE su.id = sua.submission_id AND
-                  sua.name = 'AttachTo' AND
-                  sua.value IN (:projects) AND
-                  su.version > 0)
-  </entry>
-
-  <entry key="libFileSubmissionsQuery">
-    SELECT su.id, accno, title, secretKey, released, relPath, rTime, cTime, mTime, rootSection_id, owner_id
-    FROM Submission su, SubmissionAttribute sua
-    WHERE su.id = sua.submission_id AND
-      sua.name = 'AttachTo' AND
-      sua.value IN (:projects) AND
-      su.version > 0
+    SELECT su.id, accno, title, secretKey, released, relPath, rTime, cTime, mTime, rootSection_id, owner_id,
+          (SELECT count(id)
+            FROM SubmissionAttribute sua
+            WHERE su.id = sua.submission_id AND
+              sua.name = 'AttachTo' AND
+              sua.value IN (:libFileProjects)) isLibFile
+    FROM Submission su
+    WHERE su.version > 0
   </entry>
 
   <entry key="submissionsPmcQuery">

--- a/Exporter/src/test/java/uk/ac/ebi/biostd/TestConfiguration.java
+++ b/Exporter/src/test/java/uk/ac/ebi/biostd/TestConfiguration.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import uk.ac.ebi.biostd.exporter.commons.FileUtils;
+import uk.ac.ebi.biostd.exporter.configuration.ExporterGeneralProperties;
 import uk.ac.ebi.biostd.exporter.configuration.GeneralConfiguration;
 import uk.ac.ebi.biostd.exporter.jobs.JobsPipelinesConfiguration;
 import uk.ac.ebi.biostd.exporter.persistence.Queries;
@@ -16,7 +17,7 @@ import uk.ac.ebi.biostd.exporter.test.IgnoreDuringScan;
 import uk.ac.ebi.biostd.remote.service.RemoteService;
 
 @Configuration
-@Import(GeneralConfiguration.class)
+@Import({ GeneralConfiguration.class, ExporterGeneralProperties.class })
 @ComponentScan(basePackageClasses = {
         JobsPipelinesConfiguration.class,
         Queries.class,
@@ -24,7 +25,7 @@ import uk.ac.ebi.biostd.remote.service.RemoteService;
         TasksController.class,
         RemoteService.class,
         SubmissionService.class,
-        FileUtils.class},
+        FileUtils.class },
         excludeFilters = @Filter(IgnoreDuringScan.class))
 @EnableAutoConfiguration
 public class TestConfiguration {

--- a/Exporter/src/test/java/uk/ac/ebi/biostd/exporter/persistence/dao/SubmissionDaoTest.java
+++ b/Exporter/src/test/java/uk/ac/ebi/biostd/exporter/persistence/dao/SubmissionDaoTest.java
@@ -8,7 +8,9 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import uk.ac.ebi.biostd.TestConfiguration;
 import uk.ac.ebi.biostd.exporter.model.Submission;
 import uk.ac.ebi.biostd.exporter.persistence.model.SubAndUserInfo;
 import uk.ac.ebi.biostd.exporter.utils.DateUtils;
@@ -16,6 +18,7 @@ import uk.ac.ebi.biostd.exporter.utils.DateUtils;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest
 @DirtiesContext
+@ContextConfiguration(classes = TestConfiguration.class)
 public class SubmissionDaoTest extends PersistenceTest {
 
     private static final String SUB_ID = "Test-Submission-01/01/2018";

--- a/Exporter/src/test/resources/application.yml
+++ b/Exporter/src/test/resources/application.yml
@@ -8,6 +8,8 @@ spring:
     generate-unique-name: true
 jobs:
   backend-url: http://localhost:8181/biostd
+  libFileProjects:
+  - BioImages
   pmc:
     export:
       workers: 1

--- a/Exporter/src/test/resources/application.yml
+++ b/Exporter/src/test/resources/application.yml
@@ -10,6 +10,7 @@ jobs:
   backend-url: http://localhost:8181/biostd
   libFileProjects:
   - BioImages
+  - BioVideos
   pmc:
     export:
       workers: 1

--- a/Exporter/src/test/resources/scripts/sql/private_submission.sql
+++ b/Exporter/src/test/resources/scripts/sql/private_submission.sql
@@ -1,5 +1,6 @@
 -- Submission
 INSERT INTO Submission (CTime, MTime, RTime, accNo, relPath, released, rootPath, title, version, owner_id, secretKey) VALUES (1460402396, 1460402396, 1460402396, 'S-EPMC2873748', 'S-EPMC/S-EPMCxxx748/S-EPMC2873748', true, 'S-EPMC/S-EPMCxxx748/S-EPMC2873748', 'Cost-effectiveness of a potential vaccine for human papillomavirus.', 1, 1, null);
+INSERT INTO SubmissionAttribute(name, numValue, reference, value, submission_id, ord) VALUES('AttachTo', 0, 0, 'BioImages', 1, 0);
 
 -- Sections
 INSERT INTO Section (accNo, global, parentAccNo, tableIndex, type, parent_id, submission_id, ord) VALUES (null, false, null, -1, 'Study', null, 1, null);

--- a/Exporter/src/test/resources/test_files/full.json
+++ b/Exporter/src/test/resources/test_files/full.json
@@ -25,6 +25,10 @@
         {
           "name":"Title",
           "value":"Cost-effectiveness of a potential vaccine for human papillomavirus."
+        },
+        {
+          "name": "AttachTo",
+          "value": "BioImages"
         }
       ],
       "section":{
@@ -39,20 +43,7 @@
             "value":"Human papillomavirus (HPV) "
           }
         ],
-        "files":[
-          {
-            "path":null,
-            "name":"02-0168_appT-s1.pdf",
-            "size":34984,
-            "attributes":[
-              {
-                "name":"Type",
-                "value":"application(pdf)"
-              }
-            ],
-            "type":"file"
-          }
-        ],
+        "libraryFile":"S-EPMC2873748.1.files.json",
         "subsections":[
           {
             "accno":"PMC2873748",

--- a/Exporter/src/test/resources/test_files/full.xml
+++ b/Exporter/src/test/resources/test_files/full.xml
@@ -3,6 +3,10 @@
     <submission id="1" acc="S-EPMC2873748" relPath="S-EPMC/S-EPMCxxx748/S-EPMC2873748" rtime="1460402396" ctime="1460402396" mtime="1460402396" access="~biostudies-dev@ebi.ac.uk;#1">
       <attributes>
         <attribute>
+          <name>AttachTo</name>
+          <value>BioImages</value>
+        </attribute>
+        <attribute>
           <name>RootPSubmissionath</name>
           <value>S-EPMC/S-EPMCxxx748/S-EPMC2873748</value>
         </attribute>
@@ -15,7 +19,7 @@
           <value>Cost-effectiveness of a potential vaccine for human papillomavirus.</value>
         </attribute>
       </attributes>
-      <section id="1" type="Study">
+      <section id="1" type="Study" libraryFile="S-EPMC2873748.1.files.json">
         <attributes>
           <attribute>
             <name>Title</name>
@@ -26,17 +30,6 @@
             <value>Human papillomavirus (HPV)</value>
           </attribute>
         </attributes>
-        <files>
-          <file size="34984" type="file">
-            <name>02-0168_appT-s1.pdf</name>
-            <attributes>
-              <attribute>
-                <name>Type</name>
-                <value>application(pdf)</value>
-              </attribute>
-            </attributes>
-          </file>
-        </files>
         <subsections>
           <section id="2" acc="PMC2873748" type="Publication">
             <attributes>


### PR DESCRIPTION
- Modify exporter in order to use a library file instead of the actual file list for the submissions that belong to the projects configured under "jobs.libFileProjects" property
- Add property to configure the projects that will be exported in the way described above
- Update unit tests accordingly