### PR TITLE
Avoid Empty Properties List

### DIFF
--- a/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/configuration/ExporterGeneralProperties.java
+++ b/Exporter/src/main/java/uk/ac/ebi/biostd/exporter/configuration/ExporterGeneralProperties.java
@@ -1,13 +1,17 @@
 package uk.ac.ebi.biostd.exporter.configuration;
 
 import java.util.List;
-import lombok.Data;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-@Data
+@Setter
 @Component
 @ConfigurationProperties(prefix = "jobs")
 public class ExporterGeneralProperties {
     private List<String> libFileStudies;
+
+    public List<String> getLibFileStudies() {
+        return libFileStudies.isEmpty() ? null : libFileStudies;
+    }
 }


### PR DESCRIPTION
Avoid empty properties list since template query doesn't know how to handle them